### PR TITLE
Display static texts also after student has submitted

### DIFF
--- a/dynamic_forms/fields.py
+++ b/dynamic_forms/fields.py
@@ -33,6 +33,7 @@ class LabelField(Field):
         if 'initial' not in kwargs:
             kwargs['initial'] = help_ or label
         kwargs['required'] = False
+        kwargs['disabled'] = True # displayed, but not editable
         super().__init__(*args, **kwargs)
 
     def clean(self, value):


### PR DESCRIPTION
# Description

**What?**

Change LabelField to be "disabled" so static text (which is stored in the fields) will be visible in the response, which is rendered after the student has submitted.
e.g., before the change, the text "Please give some feedback on this assignment." was not shown in the following example:
![image](https://github.com/apluslms/mooc-jutut/assets/50318434/4ea7a1a7-b017-4eb9-8197-62e1abfa7a1c)


**Why?**

Before the static text wasn't visible after the student had submitted. However, the text might include important infrormation and the lack could be confusing for students.

**How?**

Change LabelField to be "disabled", indicating it's uneditable. LabelField, which is used to display static text between questions is not editable, therefore can always use the initial value.

Fixes #20 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

I submitted different types of feedback and responded to them in Jutut, all seemed to work correctly and the static text stayed visible in the student view.

**Did you test the changes in**

- [x] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
