### PR TITLE
Use old timestamp format in feedback messages and responses

### DIFF
--- a/feedback/static/feedback.css
+++ b/feedback/static/feedback.css
@@ -444,7 +444,7 @@ body.ios .feedback-message tr .glyphicon {
 	font-size: 11px;
 	font-weight: 400;
 	line-height: 0.7;
-	margin-left: 0.1em;
+	margin-left: 0.4em;
 	margin-right: 0.2em;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;

--- a/feedback/templates/manage/_feedback_message.html
+++ b/feedback/templates/manage/_feedback_message.html
@@ -59,9 +59,7 @@
 		role="button" aria-expanded="false" tabindex=0
 		title="{% trans 'Show all feedback fields' %}"
 	>
-		<span class="timestamp">
-			{{ feedback.timestamp|date:"d/m" }} {{ feedback.timestamp|time:"H:i" }}
-		</span>
+		<span class="timestamp">{{ feedback.timestamp|naturaltime }}</span>
 	<!-- change collapse-functionality so that only the classes within the clicked message are toggled -->
 		<div class="feedback-msg-bottom only-expanded collapse">
 			<div class="btn-group btn-group-xs" role="group">
@@ -77,7 +75,7 @@
 					A+
 				</a>
 			</div>
-			<span>{{ feedback.timestamp|naturaltime }}</span>
+			<span>{{ feedback.timestamp|date:"d.m." }} {{ feedback.timestamp|time:"H:i" }}</span>
 		</div>
 	</div> <!--.panel-footer-->
 </div>

--- a/feedback/templates/manage/_response_message.html
+++ b/feedback/templates/manage/_response_message.html
@@ -134,7 +134,7 @@
 			data-trigger="hover click"
 			data-placement="bottom"
 			title="{{ form.instance.response_by.email }}"
-			> {% with time=form.instance.response_time %}{{ time|date:"d/m" }} {{ time|time:"H:i" }}{% endwith %}
+			> {{ form.instance.response_time|naturaltime }}
 		</span>
 	{% endif %}
 	<div class="response-msg-bottom">


### PR DESCRIPTION
# Description

**What?**

The old style of formatting timestamps was preferred over the new style, where the date was in awkward U.S. format.

The formatting is now `X days Y minutes ago` (again).
When the feedback message is expanded, another date can be seen on the left side in format `DAY.MONTH. HOUR:MINUTES`.

<img width="456" alt="image" src="https://github.com/apluslms/mooc-jutut/assets/38466145/76dcfdfc-1e77-43bd-852a-933ff7248bcd">

![image](https://github.com/apluslms/mooc-jutut/assets/38466145/c63d5823-6283-4d7c-8cab-7d82fec22e19)

Fixes #78
