### PR TITLE
Sort feedbacks by newest-first and filter empty messages

### DIFF
--- a/feedback/filters.py
+++ b/feedback/filters.py
@@ -211,7 +211,7 @@ class FeedbackFilter(django_filters.FilterSet):
             ('exercise', _('Exercise order')),
             ('-exercise', _('Reverse exercise order')),
     )
-    ORDER_BY_DEFAULT = 'timestamp'
+    ORDER_BY_DEFAULT = '-timestamp'
 
     response_grade = MultipleChoiceFilter(choices=Feedback.GRADE_CHOICES,
                                           extra_filter=lambda q: q.exclude(response_time=None),

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -345,7 +345,7 @@ class FeedbackQuerySet(models.QuerySet):
                 qs = qs.filter(path_key__startswith=path_filter)
         else:
             raise ValueError("exercise_id or course_id is required")
-        return qs.order_by('timestamp')
+        return qs.order_by('-timestamp')
 
 
 ResponseUploaded = namedtuple('ResponseUploaded',

--- a/feedback/templates/manage/_submitter_heading.html
+++ b/feedback/templates/manage/_submitter_heading.html
@@ -24,7 +24,7 @@
 			data-trigger="hover"
 			data-placement="top"
 			title="{% trans 'Show all feedback for this student' %}"
-			href="{{ conv.all_feedback_for_student_url }}">
+			href="{{ conv.all_feedback_for_student_url }}&contains_text=on">
 			<span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
 		</a>
 		{% for tag in user|studenttags_for_course:course %}


### PR DESCRIPTION
# Description

**What?**

Always sort feedbacks by newest-first and filter empty messages in see-all-messages-by-this-student view. This improves usability. Requested by a teacher.

Fixes #76