### PR TITLE
Include only course staff in responder filter

### DIFF
--- a/feedback/filters.py
+++ b/feedback/filters.py
@@ -314,6 +314,7 @@ class FeedbackFilter(django_filters.FilterSet):
         course = self._course
         form.fields['exercise'].queryset = Exercise.objects.filter(course=course).all()
         form.fields['student'].queryset = Student.objects.get_students_on_course(course)
+        form.fields['response_by'].queryset = course.staff.exclude(is_staff=True)
         feedbacktags = FeedbackTag.objects.filter(course=course).all()
         form.fields['tags'].set_queryset(feedbacktags)
         studenttags = StudentTag.objects.filter(course=course).all()


### PR DESCRIPTION
# Description

**What?**

The responder filter now only includes the relevant course staff.

**Why?**

This was requested by a teacher.

Fixes #86