### PR TITLE
Fix TemplateSyntaxError on respond-to-message page

### DIFF
--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -1,18 +1,19 @@
 {% load i18n %}
 {% load urltools %}
 
+{% if paginator %}
+	{% blocktranslate trimmed count count=paginator.count asvar total_messages %}
+		{{ count }} student message found
+	{% plural %}
+		{{ count }} student messages found
+	{% endblocktranslate %}
 
-{% blocktranslate trimmed count count=paginator.count asvar total_messages %}
-	{{ count }} student message found
-{% plural %}
-	{{ count }} student messages found
-{% endblocktranslate %}
-
-{% blocktranslate trimmed count count=conversations|length asvar total_conversations %}
-	in {{ count }} conversation.
-{% plural %}
-	in {{ count }} conversations.
-{% endblocktranslate %}
+	{% blocktranslate trimmed count count=conversations|length asvar total_conversations %}
+		in {{ count }} conversation.
+	{% plural %}
+		in {{ count }} conversations.
+	{% endblocktranslate %}
+{% endif %}
 
 {% if is_paginated %}
 	<nav aria-label="page navigation">


### PR DESCRIPTION
# Description

**What?**

The paginator object is not available on this page nor is it needed, since we are responding to a specific message.

Fixes #97