### PR TITLE
Zen mode for feedback tags

### DIFF
--- a/feedback/static/feedback.css
+++ b/feedback/static/feedback.css
@@ -338,6 +338,11 @@ body {
 		justify-content: flex-start;
 	}
 }
+.feedback-response-panel > .panel-body > .conversation-tag-panel > .colortag:not(:hover):not(.colortag-active) {
+	background-color: white !important;
+	color: white;
+	border: gray 1px solid;
+}
 
 /* Feedback exercise/chapter heading */
 .conversation-panel > .panel-heading {


### PR DESCRIPTION
# Description

**What?**

Inactive tags are invisible in the response panel lists.

**Why?**

Makes the UI clearer.

**How?**

Adds one CSS class. !important property must be used, as the Django colortag package uses it as well. 

Fixes #69

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Active and hovered tags are colorful. Inactive non-hovered tags are white.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
