### PR TITLE
Preserve page size selection when changing filters

### DIFF
--- a/feedback/filters.py
+++ b/feedback/filters.py
@@ -179,6 +179,15 @@ class OrderingFilter(django_filters.filters.ChoiceFilter):
         return qs.order_by(value)
 
 
+class PaginateByFilter(django_filters.filters.Filter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, widget=forms.HiddenInput)
+
+    def filter(self, queryset, value):
+        # This filter doesn't modify the queryset (no filtering)
+        return queryset
+
+
 class FeedbackFilterForm(forms.Form):
     """Add 00:00 times to timestamp inputs"""
     template_name = "manage/filter_form.html"
@@ -272,7 +281,7 @@ class FeedbackFilter(django_filters.FilterSet):
     order_by = OrderingFilter(label=_("Sort"),
                               choices=ORDER_BY_CHOICE,
                               initial=ORDER_BY_DEFAULT)
-
+    paginate_by = PaginateByFilter()
 
     class Meta:
         model = Feedback
@@ -319,6 +328,7 @@ class FeedbackFilter(django_filters.FilterSet):
         form.fields['tags'].set_queryset(feedbacktags)
         studenttags = StudentTag.objects.filter(course=course).all()
         form.fields['student_tags'].set_queryset(studenttags)
+        form.fields['paginate_by'].initial = self.data.get('paginate_by', None)
         return form
 
     @staticmethod

--- a/feedback/templates/manage/filter_form.html
+++ b/feedback/templates/manage/filter_form.html
@@ -46,6 +46,7 @@
 		<div id="order-filter-pane">
 			{% include "manage/_filter_field.html" with field=form.order_by %}
 		</div>
+		{% include "manage/_filter_field.html" with field=form.paginate_by hide_label=True %}
 		{% else %}
 		<div></div>
 		{% endif %}


### PR DESCRIPTION
# Description

**What?**

Page size is selected in the `paginate_by` select menu. Previously the page size was forgotten when the teacher made a new query in the filter feedback form. Now the page size is preserved.

**Why?**

Improves usability.

**How?**

Adds a new filter to the FeedbackFilter class. This filter does not actually filter anything. It merely stores the paginate_by parameter in the url. The form field is hidden, since we do not need a duplicate page size input field to the filter form.

Fixes #36


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Changed filters in the filter form and made sure that the page size setting is preserved. Changed the page size setting and made sure that the filters are preserved.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
