### PR TITLE
Add regex search option for text searches

### DIFF
--- a/feedback/locale/fi/LC_MESSAGES/django.po
+++ b/feedback/locale/fi/LC_MESSAGES/django.po
@@ -18,6 +18,10 @@ msgstr ""
 "X-Generator: Lokalize 2.0\n"
 
 #: feedback/filters.py
+msgid "Not a valid regex pattern"
+msgstr "Ei säännöllinen lauseke"
+
+#: feedback/filters.py
 msgid "Oldest first"
 msgstr "Vanhemmat ensin"
 
@@ -80,6 +84,17 @@ msgstr ""
 "vastaukset kirjallisten vastausten lisäksi. Haku tukee operaattoreiden "
 "'AND', 'OR' ja 'NOT' käyttöä. (Operaattorit ovat aakkoskoosta riippuvia, "
 "mutta muutoin haku on aakkoskoosta riippumaton.)"
+
+#: feedback/filters.py
+msgid "Use regex search"
+msgstr "Käytä regex-hakua"
+
+#: feedback/filters.py
+msgid ""
+"Override default search method and use case-insensitive regex search instead."
+msgstr
+"Etsi tavallisen hakumenetelmän sijaan säännöllisellä lausekkeella "
+"(case-insensitive regex)."
 
 #: feedback/filters.py
 msgid "Teacher content"

--- a/feedback/static/feedback.css
+++ b/feedback/static/feedback.css
@@ -14,6 +14,7 @@ body {
 	margin-top: 0.7em;
 	margin-bottom: 0.7em;
 	align-items: center;
+	display: flex;
 }
 .feedback-filter > label {
 	margin-bottom: 0;
@@ -27,9 +28,12 @@ body {
 .fb-filter-field {
 	display: inline;
 }
+.fb-filter-field.input-flex {
+	width: max(min(65%, 350px), 200px) !important;
+}
 .input-flex > div,
 .input-flex > input {
-	width: max(min(65%, 350px), 200px) !important;
+	width: max(100%, 200px) !important;
 }
 #filter-panel-bottom {
 	display: flex;
@@ -43,6 +47,19 @@ body {
 	float: right;
 }
 
+/* combo textsearch filter */
+label:has(~ .fb-filter-field > .combosearch) {
+	align-self: start;
+	margin-top: 0.5em;
+}
+input[type="checkbox"].combosearch {
+	margin-right: 0.3em;
+	margin-left: 0.3em;
+}
+input[type="checkbox"].combosearch + label {
+	margin-bottom: 0;
+}
+
 /* timestamp filter */
 #extra-filter-pane > div:first-child {
 	display: flex;
@@ -52,6 +69,30 @@ body {
 	flex-wrap: wrap;
 	width: calc(100% - min(30%, 150px) - 0.5em)
 }
+
+/* tag filters */
+.tag-filter-pane > .feedback-filter {
+	display: inline;
+}
+
+/* flag filters */
+.fb-filter-field:has(> #id_feedbackfilter_flags) {
+	width: 100%;
+}
+
+/* Displaying errors */
+.feedback-filter:has(> .errorlist) {
+	flex-wrap: wrap;
+	border: 1px #ebccd1;
+	background-color: #f2dede;
+	border-radius: 4px;
+}
+.feedback-filter > .errorlist {
+	width: 100%;
+	margin-bottom: 0;
+}
+
+/* responsive for different widths */
 
 @media (min-width: 750px) {
 	#filter-container {
@@ -133,9 +174,19 @@ body {
 }
 
 @media (max-width: 450px) {
+	.feedback-filter:has(> label.right-align),
+	.feedback-filter:has( #id_feedbackfilter_response_grade) {
+		flex-direction: column;
+	}
 	.feedback-filter label.right-align {
 		width: 100%;
 		text-align: left;
+	}
+	.feedback-filter:has( #id_feedbackfilter_response_grade) {
+		align-items: start;
+	}
+	.fb-filter-field.input-flex {
+		width: 100% !important;
 	}
 	.input-flex > div,
 	.input-flex > input {

--- a/feedback/templates/feedback/widgets/combo_textsearch_widget.html
+++ b/feedback/templates/feedback/widgets/combo_textsearch_widget.html
@@ -1,0 +1,18 @@
+{% spaceless %}
+{% for widget in widget.subwidgets %}
+	{% if not forloop.last %}
+		{% include widget.template_name %}
+	{% else %}
+		<div>
+			{% include widget.template_name %}
+			<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}
+				{% if widget.attrs.bool_helptext %}
+					data-toggle="tooltip" data-placement="right"
+					data-original-title="{{ widget.attrs.bool_helptext }}"
+				{% endif %}
+			>
+				{{ widget.attrs.bool_label }}
+			</label>
+		</div>
+	{% endif %}
+{% endfor %}{% endspaceless %}


### PR DESCRIPTION
# Description

**What?**

Allow user to select to use regex search for student form contents and teacher response. This is done by checking a checkbox by the field.
![Screenshot from 2024-06-03 14-49-24](https://github.com/apluslms/mooc-jutut/assets/50318434/4059f1c2-5a06-43a9-acec-e49ccc961f22)
![Screenshot from 2024-06-04 11-36-21](https://github.com/apluslms/mooc-jutut/assets/50318434/491a3193-2a7f-4a77-bf54-802a8724eb20)

Add also simple validation and error styling (because the default error message appearance breaks layout):
![Screenshot from 2024-06-04 11-35-02](https://github.com/apluslms/mooc-jutut/assets/50318434/ea9dd123-06e4-4bab-ad96-4f932452025d)

The layout and styling should work well responsively on different sizes of screens, e.g.:
![Screenshot from 2024-06-04 11-38-15](https://github.com/apluslms/mooc-jutut/assets/50318434/f26aa28e-83a8-4275-95d5-e0157ecc06e2)


**Why?**

Juha Sorva wants support for regex filtering of form contents.

**How?**

Implement filter, field and widget that allow selecting between default search method and a regex search.
Implement simple validation and error handling (also for exercise identifier, which didn't validate regex) for regex.
Change form styling to use flex, so the checkbox and label can also be positioned well.

Fixes #87 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the normal text search still seems to work, as well as the new regex search. (And that searching works also when the text field is empty). Tested also that there is a error message if the regex search is used but the search string isn't valid regex.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [x] Other documentation (mention below which documentation).

Added some documentation strings withing the code.
Perhaps Aplus manual should be updated also towards the end of the summer to provide info about new changes (e.g. this filtering, importing feedback tags, and other possible changes).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
