### PR TITLE
Change how students see teacher responses and support simple styling for teacher messages.

### DIFF
--- a/dynamic_forms/static/dynamic_forms.js
+++ b/dynamic_forms/static/dynamic_forms.js
@@ -13,7 +13,7 @@ function dynamic_forms_textarea() {
     }
     textbox.hide();
     span = $('<span class="textarea"></span>');
-    span.text(base.val() || blankResponse);
+    span.html(base.val() || blankResponse);
     if (base.data('spantarget')) {
       spanbox = $(base.data('spantarget')).first();
       spanbox.show();
@@ -47,18 +47,18 @@ function dynamic_forms_textarea() {
 
   // edit
   if (editable) {
-    var turn_edit_on = function() {
+    const turn_edit_on = function() {
       spanbox.hide();
       textbox.show();
       base.trigger('enter_edit');
       // move focus to end
       textbox.find('textarea').focus().each(function() {
-        var len = this.value.length;
+        const len = this.value.length;
         this.selectionStart = len;
         this.selectionEnd = len;
       });
     };
-    var turn_edit_off = function() {
+    const turn_edit_off = function() {
       textbox.hide();
       spanbox.show();
     };

--- a/feedback/locale/fi/LC_MESSAGES/django.po
+++ b/feedback/locale/fi/LC_MESSAGES/django.po
@@ -468,8 +468,44 @@ msgid "Respond"
 msgstr "Vastaa"
 
 #: feedback/templates/manage/_response_message.html
-msgid "The student has seen this response."
-msgstr "Opiskelija on nähnyt tämän vastauksen."
+msgid "Toggle text preview"
+msgstr "Tekstin esikatselun vaihtaminen"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Preview"
+msgstr "Esikatsele"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Hide preview"
+msgstr "Piilota esikatselu"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Hide preview and return to editing"
+msgstr "Piilota esikatselu ja palaa muokkausnäkymään"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Show styling buttons"
+msgstr "Näytä muotoilupainikkeet"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Styling buttons"
+msgstr "Muotoilupainikkeet"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Insert link"
+msgstr "Lisää linkki"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Bold"
+msgstr "Lihavointi"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Italic"
+msgstr "Kursivointi"
+
+#: feedback/templates/manage/_response_message.html
+msgid "Monospace/code"
+msgstr "Tasalevyinen/koodi"
 
 #: feedback/templates/manage/_response_message.html
 msgid "Conflict"

--- a/feedback/locale/fi/LC_MESSAGES/django.po
+++ b/feedback/locale/fi/LC_MESSAGES/django.po
@@ -720,6 +720,22 @@ msgstr "Palaute"
 msgid "Feedback <i>%(jutut)s</i> for <i>%(aplus)s</i>"
 msgstr "Palaute <i>%(jutut)s</i> palvelulle <i>%(aplus)s</i>"
 
+#: feedback/templatetags/feedback.py
+msgid "Give 0 points and send response"
+msgstr "Anna 0 pistettä ja lähetä vastaus"
+
+#: feedback/templatetags/feedback.py
+msgid "Give half points and send response"
+msgstr "Anna puolet pisteistä ja lähetä vastaus"
+
+#: feedback/templatetags/feedback.py
+msgid "Give full points and send response"
+msgstr "Anna täydet pisteet ja lähetä vastaus"
+
+#: feedback/templatetags/feedback.py
+msgid "Grade and send response"
+msgstr "Arvioi ja lähetä vastaus"
+
 #: feedback/views.py
 msgid "Edit feedback tag"
 msgstr "Muokkaa palautetägiä"

--- a/feedback/locale/fi/LC_MESSAGES/django.po
+++ b/feedback/locale/fi/LC_MESSAGES/django.po
@@ -684,6 +684,18 @@ msgid "No feedback by any student yet."
 msgstr "Ei palautetta keneltäkään."
 
 #: feedback/templates_j2/feedback/_form.html
+msgid "teacher"
+msgstr "opettaja"
+
+#: feedback/templates_j2/feedback/_form.html
+msgid "Previous responses and teacher replies"
+msgstr "Aiemmat omat vastaukset ja opettajan vastaukset"
+
+#: feedback/templates_j2/feedback/_form.html
+msgid "Previous responses"
+msgstr "Aiemmat omat vastaukset"
+
+#: feedback/templates_j2/feedback/_form.html
 msgid "show more"
 msgstr "näytä lisää"
 

--- a/feedback/static/feedback.css
+++ b/feedback/static/feedback.css
@@ -324,8 +324,9 @@ input[type="checkbox"].combosearch + label {
 	background: none;
 	border-color: rgba(150, 150, 150, 0.2);
 }
-.hover-btn > .glyphicon {
-	top: 0.2em
+.hover-btn > .glyphicon,
+.styling-btn-container .btn > .glyphicon {
+	top: 03px
 }
 .hover-btn:hover {
 	background-color: rgba(150, 150, 150, 0.3);
@@ -367,7 +368,7 @@ input[type="checkbox"].combosearch + label {
 	flex-wrap: wrap;
 }
 .feedback-response-panel > .panel-body > .conversation-panel {
-	flex: 35%;
+	flex: 37%;
 	max-width: 75%;
 	padding: 0.5em;
 }
@@ -533,6 +534,9 @@ body.ios .feedback-message tr .glyphicon {
 	min-height: 50px;
 	resize: both;
 }
+.response-message span.textarea.preview {
+	margin: 5px;
+}
 .response-message .respond-btn-container {
 	float: right;
 	margin: 0.2em;
@@ -558,13 +562,49 @@ body.ios .feedback-message tr .glyphicon {
 }
 .response-message .message-info {
 	display: flex;
-	justify-content: flex-end;
+	justify-content: space-between;
 	align-items: flex-end;
+	padding: 0 0.3em;
 }
-.response-msg-bottom {
+.styling-btn-container .btn-toolbar {
 	padding: 0.3em;
+	padding-left: 0;
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+}
+.response-msg-bottom-right {
 	display: flex;
 	align-items: flex-end;
+	justify-content: flex-end;
+}
+.response-label-container > * {
+	margin: 0.3em 0;
+}
+.status-tag-container > *,
+.upload-status {
+	margin: 0 0.3em;
+}
+
+/* Popover for styling buttons when they don't fit normally */
+.visible-xs-response {
+	display: none;
+}
+@media (max-width: 499px),
+(min-width: 701px) and (max-width: 991px) {
+	.visible-xs-response {
+		display: block;
+	}
+	.hidden-xs-response {
+		display: none;
+	}
+}
+.popover.style-buttons .popover-content{
+	padding: 4px;
+	display: flex;
+}
+.popover.style-buttons .btn-group.styling-buttons {
+	display: flex;
 }
 
 .import-form {

--- a/feedback/static/feedback.css
+++ b/feedback/static/feedback.css
@@ -537,6 +537,22 @@ body.ios .feedback-message tr .glyphicon {
 	float: right;
 	margin: 0.2em;
 }
+/* Btn-group styling fix so tooltips don't break styling. */
+.response-message .btn-group .btn ~ .btn {
+	margin-left: -1px;
+}
+.response-message .btn-group > .btn ~ .dropdown-toggle {
+	padding-right: 8px;
+	padding-left: 8px;
+}
+.response-message .respond-btn-container .dropdown-menu {
+	min-width: auto;
+	padding: 0;
+	margin-top: 0;
+}
+.response-message .respond-btn-container .dropdown-menu .btn {
+	width: 100%;
+}
 .response-message .ok-icon {
 	font-size: 0.8em;
 }

--- a/feedback/static/feedback.js
+++ b/feedback/static/feedback.js
@@ -88,27 +88,40 @@ $(function() {
     button.closest('form').submit();
   }
   function replace_with_buttons() {
-    var src = $(this);
+    const src = $(this);
     // create new form-group and select it
-    var dst = src.after('<div class="form-group buttons-for-radio"><div class="col-xs-12"><div class="btn-group btn-group-justified" role="group"></div></div></div>').next();
-    var cont = dst.find('.btn-group');
+    const dst = src.after('<div class="buttons-for-radio respond-btn-container">' +
+      '<div class="btn-group segmented" role="group">' +
+      '<button type="button" class="btn btn-sm btn-success dropdown-toggle"' +
+      ' data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">'+
+      '<span class="caret"></span><span class="sr-only">Toggle Dropdown</span>' +
+      '</button>' +
+      '<ul class="dropdown-menu"></ul>' +
+      '</div></div>').next();
+    const cont = dst.find('.btn-group.segmented');
+    const dropdown = dst.find('.dropdown-menu');
     // for every input radio, create new button
     src.find('input[type="radio"]').each(function() {
-      var radio_pure = this;
-      var radio = $(this);
-      var text = radio.parent().text();
-      var color = radio.data('color');
-      if (radio.prop('disabled')) {
-        cont.append('<div class="btn-group" role="group"></div>')
-      } else {
-        cont.append('<div class="btn-group" rule="group"><button class="btn btn-' +
-          color + '">' + text + '</button></div>');
-        var button = cont.find('button').last();
+      const radio_pure = this;
+      const radio = $(this);
+      const text = radio.parent().text();
+      const color = radio.data('color');
+      const tooltip = radio.data('tooltip-text');
+      if (!radio.prop('disabled')) {
+        const button = $('<button class="btn btn-sm btn-' + color + '" ' +
+         'data-toggle="tooltip" data-trigger="hover" title="' + tooltip + '">' +
+          text + '</button>');
+        if (color == 'success') {
+          cont.prepend(button);
+        } else {
+          dropdown.prepend($('<li></li>').append(button));
+        }
         button.data('radio', radio_pure).on('click', on_submit_button);
         if (radio.is(':checked'))
           button.addClass('active');
       }
     });
+    dst.find('[data-toggle="tooltip"]').tooltip();
     // hide original form-group
     src.hide();
   }

--- a/feedback/templates/manage/_response_message.html
+++ b/feedback/templates/manage/_response_message.html
@@ -87,6 +87,7 @@
 										{% if form.disabled %} disabled {% endif %}
 										autocomplete="off"
 										data-color="{{ choice.data.value|grade_color }}"
+										data-tooltip-text="{{ choice.data.value|grade_submit_tooltip }}"
 										{% if choice.is_checked and form.instance.responded %} checked {% endif %}
 										/>
 									{{ choice.choice_label }}

--- a/feedback/templates/manage/_response_message.html
+++ b/feedback/templates/manage/_response_message.html
@@ -125,10 +125,106 @@
 		</div> <!-- #edit-box .edit-response-->
 	</form>
 
-	{% with state=form.has_expired|yesno:"error-conflict,default" %}
+	{% with def_state=feedback.waiting_for_response_msg|yesno:"pre-edit,default" %}
+	{% with state=form.has_expired|yesno:"error-conflict,"|add:def_state %}
 	<div class="stateful message-info" data-state="{{ state }}">
-		{% if form.had.responded and form.instance.response_by %}
-			<span>
+		<div class="styling-btn-container">
+			<div class="btn-toolbar"
+				{{ state|on_state:"pre-edit edit" }}
+				data-textarea-id="{{ form.auto_id|fill_format_string:"response_msg" }}"
+			>
+				<div class="btn-group" role="group"
+					aria-label="{% translate 'Toggle text preview' %}"
+				>
+					<button type="button" class="preview-button btn btn-default btn-xs"
+						data-toggle="tooltip" data-trigger="hover" data-placement="bottom"
+						title="{% translate 'Preview' %}"
+					>
+						<span class="glyphicon glyphicon-eye-open" aria-label="{% translate 'Preview' %}"></span>
+					</button>
+					<button type="button" class="unpreview-button btn btn-default btn-xs"
+						style="display: none;"
+						data-toggle="tooltip" data-trigger="hover" data-placement="bottom"
+						title="{% translate 'Hide preview' %}"
+					>
+						<span class="glyphicon glyphicon-edit" aria-label="{% translate 'Hide preview and return to editing' %}"></span>
+					</button>
+				</div>
+				<div class="btn-group visible-xs-response">
+					<button type="button" class="toggle-styling-buttons btn btn-default btn-xs"
+					data-toggle="tooltip" data-trigger="hover" data-placement="bottom" data-html="true"
+					title="{% translate 'Show styling buttons' %}"
+				>
+					<span class="glyphicon glyphicon-option-vertical" aria-label="{% translate 'Show styling buttons' %}"></span>
+					</button>
+				</div>
+				<div class="btn-group styling-buttons hidden-xs-response" role="group" aria-label="{% translate 'Styling buttons' %}">
+					<button type="button" class="btn btn-default btn-xs"
+						data-tag="a"
+						data-toggle="tooltip" data-trigger="hover" data-placement="bottom" data-html="true"
+						title="{% translate 'Insert link' %}<br>(CTRL/⌘ + K)"
+					>
+						<span class="glyphicon glyphicon-link" aria-label="{% translate 'Insert link' %}"></span>
+					</button>
+					<button type="button" class="btn btn-default btn-xs"
+						data-tag="b"
+						data-toggle="tooltip" data-trigger="hover" data-placement="bottom" data-html="true"
+						title="{% translate 'Bold' %}<br>(CTRL/⌘ + B)"
+					>
+						<span class="glyphicon glyphicon-bold" aria-label="{% translate 'Bold' %}"></span>
+					</button>
+					<button type="button" class="btn btn-default btn-xs"
+						data-tag="i"
+						data-toggle="tooltip" data-trigger="hover" data-placement="bottom" data-html="true"
+						title="{% translate 'Italic' %}<br>(CTRL/⌘ + I)"
+					>
+						<span class="glyphicon glyphicon-italic" aria-label="{% translate 'Italic' %}"></span>
+					</button>
+					<button type="button" class="btn btn-default btn-xs"
+						data-tag="code"
+						data-toggle="tooltip" data-trigger="hover" data-placement="bottom"
+						title="{% translate 'Monospace/code' %}"
+					>
+						<span class="glyphicon glyphicon-font" aria-label="{% translate 'Monospace/code' %}"></span>
+					</button>
+				</div>
+			</div>
+		</div> <!-- .styling-button-container -->
+		<div class="response-msg-bottom-right">
+			<div class="response-label-container">
+				<span
+					class="label label-default"
+					{{ state|on_state:"error-conflict" }}
+					>{% trans "Conflict" %}</span>
+				<span
+					class="label label-default"
+					{{ state|on_state:"edit" }}
+					>{% trans "not saved" %}</span>
+				<button
+					class="btn btn-danger btn-xs cancel-button"
+					data-textarea-id="{{ form.auto_id|fill_format_string:"response_msg" }}"
+					{{ state|on_state:"edit" }}
+					>{% trans "Cancel" %}</button>
+				{% if form.had.responded and not form.instance.response_by %}
+					<span
+						class="label label-info"
+						{{ state|on_state:"default" }}
+						rel="tooltip"
+						data-toggle="tooltip"
+						data-trigger="hover click"
+						data-placement="top"
+						title="{% trans "This feedback was automatically accepted" %}"
+						>
+						{% trans "auto" %}
+					</span>
+				{% endif %}
+			</div>
+			<div class="status-tag-container"
+				{{ state|on_state:"default error-conflict" }}
+			></div>
+			{% include "manage/_upload_status.html" %}
+			{% if form.had.responded and form.instance.response_by %}
+			<span {{ state|on_state:"default error-conflict" }}>
 				{% if feedback.response_seen %}
 					<span
 						class="glyphicon glyphicon-ok ok-icon"
@@ -141,7 +237,6 @@
 					</span>
 				{% endif %}
 				<span class="timestamp"
-					{{ state|on_state:"default error-conflict" }}
 					rel="tooltip"
 					data-toggle="tooltip"
 					data-trigger="hover click"
@@ -150,42 +245,10 @@
 					> {{ form.instance.response_time|naturaltime }}
 				</span>
 			</span>
-		{% endif %}
-	<div class="response-msg-bottom">
-		<div class="response-label-container">
-			<span
-				class="label label-default"
-				{{ state|on_state:"error-conflict" }}
-				>{% trans "Conflict" %}</span>
-			<span
-				class="label label-default"
-				{{ state|on_state:"edit" }}
-				>{% trans "not saved" %}</span>
-			<button
-				class="btn btn-danger btn-xs cancel-button"
-				data-textarea-id="{{ form.auto_id|fill_format_string:"response_msg" }}"
-				{{ state|on_state:"edit" }}
-				>{% trans "Cancel" %}</button>
-			{% if form.had.responded and not form.instance.response_by %}
-				<span
-					class="label label-info"
-					{{ state|on_state:"default" }}
-					rel="tooltip"
-					data-toggle="tooltip"
-					data-trigger="hover click"
-					data-placement="top"
-					title="{% trans "This feedback was automatically accepted" %}"
-					>
-					{% trans "auto" %}
-				</span>
 			{% endif %}
-		</div>
-		<div class="status-tag-container"
-			{{ state|on_state:"default error-conflict" }}
-		></div>
-		{% include "manage/_upload_status.html" %}
-	</div> <!-- .response-msg-bottom -->
+		</div> <!-- .response-msg-bottom-right -->
 	</div>
+	{% endwith %}
 	{% endwith %}
 </div>
 </div> <!--.response-message-container-->

--- a/feedback/templates/manage/_upload_status.html
+++ b/feedback/templates/manage/_upload_status.html
@@ -11,7 +11,7 @@
 {% with upl=feedback.response_uploaded %}
 	{% if feedback.responded and not upl.ok %}
 		<span rel="tooltip"
-			class="label label-{{ upl.code|yesno:"danger,default" }} pull-right  upload_status"
+			class="label label-{{ upl.code|yesno:"danger,default" }} pull-right upload-status"
 			data-updateurl="{{ status_url|default:request.get_full_path }}"
 			data-code="{{ upl.code }}"
 			{% if upl.code %}

--- a/feedback/templates_j2/feedback/_form.html
+++ b/feedback/templates_j2/feedback/_form.html
@@ -18,7 +18,7 @@
 	{% if message %}
 		<li class="list-group-item list-group-item-info staff" style="{% if index > 2 %}display: none;{% endif %}">
 			{{ glyph("education", _("teacher")) }}
-			<span class="text">{{ message }}</span>
+			<span class="text">{{ message|safe }}</span>
 		</li>
 	{% endif %}
 {% endmacro -%}
@@ -167,7 +167,7 @@
 					".jutut-exercise.jutut-v2 .show-more { margin: 0 0 -6px; padding: 0; text-align: center; cursor: pointer; } " +
 					".jutut-exercise.jutut-v2 li { margin: 3px 0; border-radius: 4px; } " +
 					".jutut-exercise.jutut-v2 li .text { white-space: pre-wrap; } " +
-					".jutut-exercise.jutut-v2 li.staff { margin-left: 15%; padding-left: 32px; } " +
+					".jutut-exercise.jutut-v2 li.staff { margin-left: 15%; padding-left: 32px; color: #333; } " +
 					".jutut-exercise.jutut-v2 li.staff .glyphicon { position: absolute; top: 12px; left: 12px; color: #5d5d5d; } " +
 					".jutut-exercise.jutut-v2 li.student { margin-right: 15%;} " +
 					".modal-content .jutut-exercise.jutut-v2 li.student:not(:has(~ .student)) { border: solid 2px #66afe9; } "

--- a/feedback/templates_j2/feedback/_form.html
+++ b/feedback/templates_j2/feedback/_form.html
@@ -2,8 +2,14 @@
 {#
   Template for bootstrap glyph
 -#}
-{% macro glyph(name) -%}
-	<span class="glyphicon glyphicon-{{name}}" aria-hidden="true"></span>
+{% macro glyph(name, arialabel=none) -%}
+	<span class="glyphicon glyphicon-{{name}}"
+		{%- if arialabel-%}
+			aria-label="{{ arialabel }}"
+		{%- else -%}
+			aria-hidden="true"
+		{%- endif -%}
+	></span>
 {% endmacro -%}
 {#
   Staff reponse template
@@ -11,7 +17,7 @@
 {% macro staff_response(message, index=0) -%}
 	{% if message %}
 		<li class="list-group-item list-group-item-info staff" style="{% if index > 2 %}display: none;{% endif %}">
-			{{ glyph("education") }}
+			{{ glyph("education", _("teacher")) }}
 			<span class="text">{{ message }}</span>
 		</li>
 	{% endif %}
@@ -19,56 +25,98 @@
 {#
   Student message template
 -#}
-{% macro student_message(messages, index=0) -%}
+{% macro student_message(messages, f_key, index=0) -%}
 	<li class="list-group-item student" style="{% if index > 2 %}display: none;{% endif %}">
-		{% if messages|length > 1 %}
-			{% for key, text in messages %}
-				{% if not loop.first %}<br>{% endif %}
-				<b>{{ key }}</b><br>
+		{%- for key, text in messages -%}
+			{% if key == f_key -%}
 				<span class="text">{{ text }}</span>
-			{% endfor %}
-		{% else %}
-			{% for key, text in messages %}
-				<span class="text">{{ text }}</span>
-			{% endfor %}
-		{% endif %}
+			{%- endif %}
+		{%- endfor -%}
 	</li>
 {% endmacro -%}
+{% macro well(older_count, show_teacher=true, f_key=none) -%}
+	{%- if show_teacher -%}
+		{% set sr_text = _("Previous responses and teacher replies") %}
+	{%- else -%}
+		{% set sr_text = _("Previous responses") %}
+	{%- endif -%}
+	<div class="well" style="margin-bottom: 6px;">
+		<span class="sr-only">{{ sr_text }}</span>
+		<ul class="list-group nav" style="margin-bottom: 0;">
+			{% if older_count > 2 -%}
+				<li class="show-more">
+					{{ glyph("menu-up") }} {{ _("show more") }} {{ glyph("menu-up") }}
+				</li>
+			{%- endif %}
+
+			{%- for oldfb in feedback.older_versions|reverse -%}
+				{%- if f_key -%}
+					{{ student_message(oldfb.text_feedback, f_key, loop.revindex) }}
+				{%- endif -%}
+				{%- if show_teacher -%}
+					{{ staff_response(oldfb.response_msg, loop.revindex) }}
+				{%- endif -%}
+			{%- endfor -%}
+
+			{%- if f_key-%}
+				{{ student_message(feedback.text_feedback, f_key) }}
+			{%- endif -%}
+			{%- if feedback.response_msg and show_teacher -%}
+				{{ staff_response(feedback.response_msg) }}
+			{%- endif -%}
+		</ul>
+	</div>
+{%- endmacro -%}
 {#
   Main block
 -#}
 <div class="jutut-exercise jutut-v2" lang="{{ get_current_language() }}">
-
-	{# Response #}
-	{% if feedback %}
-		{% set older_count = feedback.older_versions.count() %}
-		{% if feedback.response_msg or older_count > 0 %}
-			<div class="well">
-				<ul class="list-group nav" style="margin-bottom: 0;">
-					{% if older_count > 2 %}
-						<li class="show-more">
-							{{ glyph("menu-up") }} {{ _("show more") }} {{ glyph("menu-up") }}
-						</li>
-					{% endif %}
-
-					{% for oldfb in feedback.older_versions|reverse %}
-						{{ student_message(oldfb.text_feedback, loop.revindex) }}
-						{{ staff_response(oldfb.response_msg, loop.revindex) }}
-					{% endfor %}
-
-					{{ student_message(feedback.text_feedback) }}
-					{% if feedback.response_msg %}
-						{{ staff_response(feedback.response_msg) }}
-					{% endif %}
-				</ul>
-			</div>
-		{% endif %}
-	{% endif %}
-
-	{# Form #}
+	{#- Form -#}
 	<form id="{{ form_id }}" action="{{ post_url }}" method="post" class="form">
+		{%- if feedback -%}
+			{% set older_count = feedback.older_versions.count() %}
+			{%- if form is has_textfields -%}
 
-		{{ form|bootstrap }}
+				{%- if form.non_field_errors() -%}
+					<div class="alert alert-danger">
+						<a class="close" data-dismiss="alert">&times;</a>
+						{%- for non_field_error in form.non_field_errors() -%}
+							{{ non_field_error }}
+						{%- endfor -%}
+					</div>
+				{%- endif -%}
+
+				{%- for field in form -%}
+					{%- if field.is_text -%}
+						<div class="form-group">
+							<div class="{{ field.css_classes() }}">
+								{%- if field.auto_id and field.label -%}
+									<label class="control-label {% if field.field.required %}{{ form.required_css_class or 'required' }}{% endif %}" for="{{ field.auto_id }}">{{ field.label }}</label>
+								{%- endif -%}
+								{%- if field.help_text -%}
+									<div class="help-block">
+										{{ field.help_text|safe }}
+									</div>
+								{%- endif -%}
+								{#- Old versions and teacher responses (if main text feedback) -#}
+								{{ well(older_count, field is primary_textfeedback, field.name) }}
+								{{- field|bootstrap_classes -}}
+								{%- for error in field.errors -%}
+									<span class="help-block {{ form.error_css_class or 'error-msg' }}">{{ error }}</span>
+								{%- endfor -%}
+							</div>
+						</div>
+					{%- else -%}
+						{{ field|bootstrap }}
+					{%- endif -%}
+				{%- endfor -%}
+			{%- else -%} {# render possible teacher responses even though there isn't text feedback -#}
+				{{ well(older_count) }}
+				{{ form|bootstrap }}
+			{%- endif -%}
+		{%- else -%}
+			{{ form|bootstrap }}
+		{%- endif -%}
 
 		<div class="only-when-edited alert alert-warning" style="display: none;">
 			{{ _("This feedback has unsaved changes!") }}
@@ -91,24 +139,27 @@
 	{# UI interaction #}
 	<script>
 		(function($) {
+			const f = $('#{{ form_id }}');
+			{# implement show more #}
+			const c = f.find('.well'), m = c.find('.show-more');
+			m.click(function() { c.find('li').show(); m.hide(); });
+			{# empty textfields #}
+			c.next('textarea, input[type="text"]').val("");
 			{# implement edited notification #}
-			var f = $('#{{ form_id }}'),
-				o = f.find('.only-when-edited'),
-				i = f.serialize(), s = false;
+			const o = f.find('.only-when-edited'), i = f.serialize();
+			let s = false;
 			f.removeAttr('id');
 			f.find(':input').on('change input', function() {
-				var n = f.serialize() !== i;
+				const n = f.serialize() !== i;
 				if (s !== n) o.toggle(s = n);
 			});
 			f.find("input[type='reset']").on('click', function(e) {
 				e.preventDefault();
 				f.each(function(){this.reset();});
+				c.next('textarea, input[type="text"]').val("");
 				o.hide(); s = false;
 			});
 			o.hide();
-			{# implement show more #}
-			var c = f.prev(), m = c.find('.show-more');
-			m.click(function() { c.find('li').show(); m.hide(); });
 			{# inject styles #}
 			if ($('#jutut-v2').length==0)
 				$('<style id="jutut-v2"></style>').appendTo(document.head).text(
@@ -118,7 +169,8 @@
 					".jutut-exercise.jutut-v2 li .text { white-space: pre-wrap; } " +
 					".jutut-exercise.jutut-v2 li.staff { margin-left: 15%; padding-left: 32px; } " +
 					".jutut-exercise.jutut-v2 li.staff .glyphicon { position: absolute; top: 12px; left: 12px; color: #5d5d5d; } " +
-					".jutut-exercise.jutut-v2 li.student { margin-right: 15%;} "
+					".jutut-exercise.jutut-v2 li.student { margin-right: 15%;} " +
+					".modal-content .jutut-exercise.jutut-v2 li.student:not(:has(~ .student)) { border: solid 2px #66afe9; } "
 				);
 		})(jQuery);
 	</script>

--- a/feedback/templatetags/feedback.py
+++ b/feedback/templatetags/feedback.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 from django import template
 from django.forms.utils import flatatt
+from django.utils.translation import gettext_lazy as _
 
 
 register = template.Library()
@@ -23,6 +26,16 @@ def select_from_list(index, list_):
 def grade_color(grade):
     colors = ['danger', 'warning', 'success']
     return select_from_list(grade, colors) or 'default'
+
+
+@register.filter
+def grade_submit_tooltip(grade: Optional[int]) -> str:
+    tooltip = [
+        _("Give 0 points and send response"),
+        _("Give half points and send response"),
+        _("Give full points and send response"),
+    ]
+    return select_from_list(grade, tooltip) or _("Grade and send response")
 
 
 @register.filter

--- a/feedback/templatetags/jinja_tests.py
+++ b/feedback/templatetags/jinja_tests.py
@@ -1,0 +1,32 @@
+from django_jinja import library
+from jinja2 import pass_context
+
+from dynamic_forms.fields import EnchantedBoundField
+
+
+@library.test(name="has_textfields")
+def is_has_textfields(form) -> bool:
+    """Check if form has any text fields."""
+    for field in form:
+        if isinstance(field, EnchantedBoundField) and field.is_text:
+            return True
+    return False
+
+@library.test(name="primary_textfeedback")
+@pass_context
+def is_primary_textfeedback(ctx, field) -> bool:
+    """Check if this field is the primary text feedback of the form.
+    If a form has a question with the flag 'main-feedback', that field
+    is the primary text feedback field. If not, the last text feedback
+    is considered the primary text feedback.
+    """
+    if 'main-feedback-question' in field.css_classes():
+        return True
+    form = ctx.get('form')
+    last_text_field = None
+    for f in form:
+        if isinstance(f, EnchantedBoundField) and f.is_text:
+            if 'main-feedback-question' in f.css_classes():
+                return False
+            last_text_field = f
+    return field == last_text_field


### PR DESCRIPTION
This probably should have been two different PR's but since they were related to how thing appear to the student, I started making them in the same branch. Sorry about that.


# Show text responses immediately above text fields for students 

**What?**

Change student view so the responses sent by the student are shown
immediately above the text field and empty the text field.
![Screenshot from 2024-07-08 16-55-21](https://github.com/user-attachments/assets/807ad9ac-5d76-4a09-8eae-118c66ac154e)
![Screenshot from 2024-07-08 16-56-01](https://github.com/user-attachments/assets/c968f0c7-a647-4a45-a7e0-b11809ed4842)

If there are several text fields, display teacher responses by the
"primary" text feedback field, which is either a text field with the
flag "main-feedback" (if any field has the flag) or the last text field.

Change also the modal submission preview so it highlights the last
message from the student with a blue border.
![Screenshot from 2024-07-09 11-39-00](https://github.com/user-attachments/assets/d6b0b9e5-d48d-4216-9b13-64b7b4a56621)


**Why?**
This should make it clearer to the student that sending another response
does not edit the previous response but sends a new message.
This also means that messages don't need to indicate which field the
response was from (using the field key).

**How?**
Change rendering in jinja template

Fixes #54 
Fixes #52

# Enable simple styling of teacher messages

**What?**

Allow teacher messages to be styled using HTML tags.

- Add a preview functionality so the teacher can see before sending how the message appears and everything works.
- Add styling buttons that automatically add (or remove) the proper tags around highlighted text (for inserting link, bold, italic, monospace).
- Enable also keyboard shortcuts for inserting link, bold, italic (and underline) tags.

Style buttons have tooltips. Tags are place around selected text (or cursor if none is selected), with the text being selected afterwards as well. If the button is pressed (and the tag in question is around selected text), the appropriate tags are removed. (Same for keyboard shortcuts).
For links, the cursor is placed where the url would go.
![Screenshot from 2024-07-12 17-14-24](https://github.com/user-attachments/assets/494f5c29-cc27-436a-90eb-3b335ea95e84)
After clicking the preview button, the user can see how the response would appear. The styling buttons are disabled, and the preview button is replace with a button for going back to the editing view.
![Screenshot from 2024-07-12 17-15-21](https://github.com/user-attachments/assets/275e766f-c951-4bea-b731-3c4c14eede8d)
The message after being sent.
![Screenshot from 2024-07-12 17-13-34](https://github.com/user-attachments/assets/7f733d67-af79-44c6-9621-af27be5996f9)

If the styling buttons wouldn't fit in the box, they are placed in a popover which appears when the toggle button is pressed.
![Screenshot from 2024-07-12 17-22-10](https://github.com/user-attachments/assets/c1cfe103-2907-4335-984e-81b180063709)
![Screenshot from 2024-07-12 17-22-27](https://github.com/user-attachments/assets/4302f073-50d1-4e51-9933-037ceca84b3b)


For feedback that requires grading, change the radio button (+ submit) replacement buttons from a block button group to a segmented button with dropdown toggle. This as the "Good" (full points) option be the default option visible and the two other options available in the dropdown.
![Screenshot from 2024-07-12 17-14-53](https://github.com/user-attachments/assets/eb2be95b-77ef-4e14-a563-b43df3a5df3c)



**Why?**

Enable styling for teacher messages.

**How?**

Javascript, jQuery, adding buttons and event listeners, etc.
Any HTML can be written in the field (and it's not sanitized). Styling buttons and keyboard shortcuts are provided for better UX experience.

Fixes #93


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [x] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Screen reader (for the student view)
Testing different ways of editing teacher responses (and adding/removing tags), and that the right things disappear and appear when submitting (or going editing) despite if the message had been sent from the editing view or preview view.
Tested with different screen widths.

Tested keyboard shortcuts on Linux with Firefox. Keyboard shortcuts should be also tested with Mac.

**Did you test the changes in**

- [x] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
