### PR TITLE
Add regrade_when_notification_seen on feedback comment

### DIFF
--- a/feedback/utils.py
+++ b/feedback/utils.py
@@ -45,6 +45,7 @@ def update_response_to_aplus(feedback):
     }
     if feedback.response_notify:
         update_data['notify'] = feedback.response_notify_aplus
+        update_data['regrade_when_notification_seen'] = True
 
     r = client.grade(update_data, timeout=(6.4, 46))
     feedback.response_uploaded = r.status_code


### PR DESCRIPTION
Sends a regrade_when_notification_seen parameter with the request sent to A+ when a teacher responds to feedback. This is done to differentiate notification-generating requests that should send a request for re-grading (e.g. jutut feedback seen) from ones that shouldn't (manually graded exercise). In the end I went with this instead of a separate ping URL to avoid complexity.

Requires the corresponding change in a-plus (https://github.com/apluslms/a-plus/pull/1383).