### PR TITLE
Change button for link to conversation to copy

### DIFF
--- a/feedback/locale/fi/LC_MESSAGES/django.po
+++ b/feedback/locale/fi/LC_MESSAGES/django.po
@@ -431,8 +431,12 @@ msgid "Show all feedback for this execise"
 msgstr "Näytä kaikki palautteet tähän tehtävään"
 
 #: feedback/templates/manage/_exercise_heading.html
-msgid "Show feedback for this execise by the student"
-msgstr "Näytä tämän opiskelijan palautteet tähän tehtävään"
+msgid "Copy link to this conversation"
+msgstr "Kopioi linkki tähän keskusteluun"
+
+#: feedback/templates/manage/_exercise_heading.html
+msgid "The link was copied to the clipboard"
+msgstr "Linkki kopioitiin leikepöydälle"
 
 #: feedback/templates/manage/_feedback_message.html
 msgid "This field was <b>not</b> required"

--- a/feedback/static/feedback.js
+++ b/feedback/static/feedback.js
@@ -407,3 +407,33 @@ window.addEventListener("load", (event) => {
     cur.onkeydown = toggleShowAll;
   }
 });
+
+async function copyToClipboard(text, elem) {
+  const popoverOpts = {
+    template: '<div class="popover" role="tooltip"><div class="arrow"></div><div class="popover-content"></div></div>',
+    trigger: 'manual',
+  };
+  try {
+    await navigator.clipboard.writeText(text);
+    if (elem) {
+      btn = $(elem);
+      btn.tooltip('hide').popover({
+        ...popoverOpts,
+        content: elem.dataset.copyNotification || "'" + text + "' was copied to the clipboard",
+      }).popover('show');
+      setTimeout(() => { btn.popover('hide'); }, 2000);
+    }
+  } catch (error) {
+    console.error(error.message);
+    if (elem) {
+      btn = $(elem);
+      btn.tooltip('hide').popover({
+        ...popoverOpts,
+        content: "Unable to copy to clipboard: " + text,
+      }).popover('show');
+      setTimeout(() => { btn.popover('hide'); }, 5000);
+    } else {
+      console.log("Unable to copy to clipboard: " + text);
+    }
+  }
+}

--- a/feedback/templates/manage/_exercise_heading.html
+++ b/feedback/templates/manage/_exercise_heading.html
@@ -28,15 +28,17 @@
 			href="{{ conv.all_feedback_for_exercise_url }}">
 			<span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
 		</a>
-		<a
+		<button
 			class="btn btn-xs hover-btn"
 			data-toggle="tooltip"
 			data-trigger="hover"
 			data-placement="top"
-			title="{% trans 'Show feedback for this execise by the student' %}"
-			href="{{ conv.student_feedback_for_exercise_url }}">
+			title="{% trans 'Copy link to this conversation' %}"
+			data-copy-notification="{% trans 'The link was copied to the clipboard' %}"
+			onclick="copyToClipboard('{{ conv.student_feedback_for_exercise_url }}', this)"
+		>
 			<span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-		</a>
+		</button>
 	</div>
 	<div class="feedback-context-container">
 		<div class="btn-toolbar pull-right feedback-context">

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -543,7 +543,9 @@ def update_context_for_feedbacks(request, context, course=None, feedbacks=None, 
             'student_aplus_url': course.html_url + f'teachers/participants/{conv.student.api_id}',
             'background_url': '', #TODO
             'all_feedback_for_exercise_url' : get_all_feedbacks_for_exercise_url(conv),
-            'student_feedback_for_exercise_url': get_all_student_feedbacks_for_exercise_url(conv),
+            'student_feedback_for_exercise_url': (
+                request.build_absolute_uri(get_all_student_feedbacks_for_exercise_url(conv))
+            ),
             'context_tags': context_tags,
             'conversation_tags': set(conv.tags.all()),
             'feedback_list': conv_feedback,


### PR DESCRIPTION
# Description

**What?**

Change the button for the link to a conversation (feedback responses to exercise by specific student) so that it copies the link to the clipboard rather than redirecting to said page.
Change tooltip text respectively.

If copying the text to clipboard works (secure connection and permission to write to clipboard), there is a popover open for ~2 seconds:
![Screenshot from 2024-07-26 14-30-23](https://github.com/user-attachments/assets/97aca879-6559-4248-8a64-8f036ac294e7)

If copying didn't work, there is a popover open for ~5 seconds, which notifies that it didn't work and provides the link text (so it can be copied manually):
![Screenshot from 2024-07-26 14-29-52](https://github.com/user-attachments/assets/f3966e7a-f5f8-423a-8ba2-fee02341873f)


**Why?**

Because typically the teacher doesn't actually want to go to the page displaying just that conversation, only copy the link so they can send it to another teacher or save it for themselves.

**How?**

Changing the "button" from a link to an actual button (to reflect behavior) and adding an onclick handler that copies the link text to the clipboard.

Fixes #62 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

I tested that without a secure connection (e.g. with the domain being something like 172.18.0.4) clicking on the button works as it should (popover indicates copying didn't work, provides text, stays open for ~5 seconds). When running on a secure connection (localhost), the button works as it should, the link is copied to the clipboard, and there is a popover notifying that the link was copied to the clipboard (stays open for ~2 seconds).

**Did you test the changes in**

- [x] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
