### PR TITLE
Add zen mode for feedback tags

### DIFF
--- a/feedback/locale/fi/LC_MESSAGES/django.po
+++ b/feedback/locale/fi/LC_MESSAGES/django.po
@@ -417,6 +417,18 @@ msgid "Unable to fetch student's response."
 msgstr "Opiskelijan vastauksen hakeminen ei onnistunut."
 
 #: feedback/templates/manage/_conversations_as_list.html
+msgid ""
+"Turns inactive feedback tags invisible. The feedback tag buttons reappear "
+"when hovering over the tag panel."
+msgstr ""
+"Muuttaa epäaktiiviset palautetägit näkymättömiksi. Palautetägipainikkeet "
+"näkyvät, kun hiiri on tägikentän päällä."
+
+#: feedback/templates/manage/_conversations_as_list.html
+msgid "Zen mode"
+msgstr "Zen-tila"
+
+#: feedback/templates/manage/_conversations_as_list.html
 msgid "No feedback shown as there are errors in the filter form"
 msgstr "Palautteita ei näytetä, sillä lomakkeessa on virhe"
 

--- a/feedback/static/feedback.css
+++ b/feedback/static/feedback.css
@@ -7,6 +7,16 @@ body {
 	margin-right: 0.4em;
 }
 
+#pagination-and-zen {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+}
+#zen-mode {
+	display: none;
+	flex-shrink: 0;
+	margin-bottom: 10px;
+}
 
 /* Filter panel */
 
@@ -341,6 +351,17 @@ input[type="checkbox"].combosearch + label {
 	}
 	.feedback-response-panel > .panel-body > .conversation-tag-panel {
 		justify-content: flex-start;
+	}
+}
+
+@media (hover: hover) {
+	#zen-mode {
+		display: block;
+	}
+	body:has( #zen-mode-cb:checked) .conversation-tag-panel:not(:hover):not(:has( *:focus-visible)) > .colortag:not(.colortag-active) {
+		background-color: white;
+		color: white;
+		border: var(--colortag-inactive-color) 1px solid;
 	}
 }
 

--- a/feedback/static/feedback.js
+++ b/feedback/static/feedback.js
@@ -545,6 +545,15 @@ function toggleShowAll(event) {
 
 
 window.addEventListener("load", (event) => {
+
+  /* Set up zen mode checkbox (persist state on reload) */
+  if (localStorage.getItem('zenMode') == "true") {
+    document.getElementById("zen-mode-cb").checked = true;
+  }
+  document.getElementById("zen-mode-cb").addEventListener('change', (e) => {
+    localStorage.setItem('zenMode', e.target.checked);
+  });
+
   /* Set up showall buttons */
   const showallDivs = document.getElementsByClassName("toggle-showall");
   for (let i = 0; i < showallDivs.length; i++) {

--- a/feedback/templates/manage/_conversations_as_list.html
+++ b/feedback/templates/manage/_conversations_as_list.html
@@ -8,7 +8,19 @@
 {% endcomment %}
 
 {% include "_errors_box.html" %}
-{% include "_pagination.html" %}
+<div id="pagination-and-zen">
+	{% include "_pagination.html" %}
+
+	<div id="zen-mode"
+		data-toggle="tooltip"
+		title="{% translate 'Turns inactive feedback tags invisible. The feedback tag buttons reappear when hovering over the tag panel.' %}"
+	>
+		<input type="checkbox" id="zen-mode-cb" name="zen-mode-cb">
+		<label for="zen-mode-cb">
+			{% translate 'Zen mode' %}
+		</label>
+	</div>
+</div>
 
 {% for conv in conversations %}
 	<div class="panel panel-default feedback-response-panel">


### PR DESCRIPTION
# Description

**What?**

Add "zen mode", where the inactive feedback tags are white (lightly outlined) in the feedback message panels.
The feedback tags turn visible when the cursor is in the the tag panel (or when the focus has been moved there with keyboard navigation).

The user can select to use this mode by checking a checkbox. The mode is in use (and the opt-in checkbox is visible) only on devices where hovering is possible.

The checkbox state persists even when the page is reloaded or the user goes to a new page.

[Screencast from 2024-08-20 14:03:01.webm](https://github.com/user-attachments/assets/1fde526b-1d8b-47cf-bf22-174903facd4b)


**Why?**

Can make the page feel less cluttered and help the user focus on relevant information.

**How?**

Mostly CSS.
JavaScript and localStrorage are used to save the checkbox state.

Fixes #69


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the feedback tags turn visible when the mouse is over the feedback tag panel.
Tested that checkbox state persists.
Tested using the inspect tool that the zen mode is not in use (and the checkbox isn't visible) when hover isn't possible.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
